### PR TITLE
Remove .key file after using it.

### DIFF
--- a/checkout/action.yml
+++ b/checkout/action.yml
@@ -43,6 +43,7 @@ runs:
         head .key
         echo ...
         echo "key=${key}" >> "${GITHUB_OUTPUT}"
+        rm .key
       shell: bash
       working-directory: ${{ inputs.path }}
     - uses: actions/cache/restore@v3


### PR DESCRIPTION
The checkout action should leave the repository "clean". As far as I can tell the `.key` file is not used in subsequent steps so it can be removed.